### PR TITLE
Extend type uid impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ version = "0.1.2"
 dependencies = [
  "base16",
  "bytes",
+ "casper-contract-sdk",
  "casper-executor-wasm-common",
  "casper-executor-wasm-interface",
  "casper-storage",

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -764,7 +764,7 @@ where
             | StoredValue::Message(_)
             | StoredValue::Prepayment(_)
             | StoredValue::EntryPoint(_)
-            | StoredValue::RawBytes(_) => Ok(()),
+            | StoredValue::TaggedBytes(_) => Ok(()),
         }
     }
 

--- a/executor/wasm_host/Cargo.toml
+++ b/executor/wasm_host/Cargo.toml
@@ -13,6 +13,7 @@ base16 = "0.2"
 bytes = "1.10"
 casper-executor-wasm-common = { version = "0.1.2", path = "../wasm_common" }
 casper-executor-wasm-interface = { version = "0.1.2", path = "../wasm_interface" }
+casper-contract-sdk = { version = "0.1.2", path = "../../smart_contracts/sdk" }
 casper-storage = { version = "2.1.0", path = "../../storage" }
 casper-types = { version = "6.0.0", path = "../../types" }
 either = "1.15"

--- a/executor/wasm_host/src/abi.rs
+++ b/executor/wasm_host/src/abi.rs
@@ -7,6 +7,7 @@ pub(crate) struct ReadInfo {
     pub(crate) data: u32,
     /// Size in bytes.
     pub(crate) data_size: u32,
+    pub(crate) data_type: u64,
 }
 
 unsafe impl TriviallyTransmutable for ReadInfo {}

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -34,12 +34,13 @@ use casper_types::{
     ByteCodeKind, CLType, CLValue, ContractRuntimeTag, Digest, EntityAddr, EntityEntryPoint,
     EntityKind, EntryPointAccess, EntryPointAddr, EntryPointPayment, EntryPointType,
     EntryPointValue, HashAddr, HostFunctionV2, Key, Package, PackageHash, ProtocolVersion,
-    StoredValue, URef, U512,
+    StoredValue, URef, U512, TaggedBytes,
 };
 use either::Either;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use tracing::{error, info, warn};
+use casper_contract_sdk::type_uid::TypeUid;
 
 use crate::{
     abi::{CreateResult, ReadInfo},
@@ -116,6 +117,7 @@ pub fn casper_write<S: GlobalStateReader, E: Executor>(
     key_size: u32,
     value_ptr: u32,
     value_size: u32,
+    value_type_uid: u64,
 ) -> VMResult<u32> {
     let write_cost = caller.context().config.host_function_costs().write;
     charge_host_function_call(
@@ -183,7 +185,8 @@ pub fn casper_write<S: GlobalStateReader, E: Executor>(
 
     let stored_value = match keyspace {
         Keyspace::State | Keyspace::Context(_) | Keyspace::NamedKey(_) => {
-            StoredValue::RawBytes(value)
+            let tagged_bytes = TaggedBytes::new(value_type_uid, value.into());
+            StoredValue::TaggedBytes(tagged_bytes)
         }
         Keyspace::PaymentInfo(_) => {
             let entry_point_payment = match value.as_slice() {
@@ -405,16 +408,20 @@ pub fn casper_read<S: GlobalStateReader, E: Executor>(
     };
     let global_state_read_result = caller.context_mut().tracking_copy.read(&global_state_key);
 
-    let global_state_raw_bytes: Cow<[u8]> = match global_state_read_result {
-        Ok(Some(StoredValue::RawBytes(raw_bytes))) => Cow::Owned(raw_bytes),
+    let (type_uid, global_state_raw_bytes): (u64, Cow<[u8]>) = match global_state_read_result {
+        Ok(Some(StoredValue::TaggedBytes(raw_bytes))) => {
+            let (type_uid, bytes) = raw_bytes.deconstruct();
+            (type_uid, Cow::Owned(bytes.take_inner()))
+        },
         Ok(Some(StoredValue::EntryPoint(EntryPointValue::V1CasperVm(entry_point)))) => {
-            match entry_point.entry_point_payment() {
+            let bytes: Cow<[u8]> = match entry_point.entry_point_payment() {
                 EntryPointPayment::Caller => Cow::Borrowed(&[ENTRY_POINT_PAYMENT_CALLER]),
                 EntryPointPayment::DirectInvocationOnly => {
                     Cow::Borrowed(&[ENTRY_POINT_PAYMENT_DIRECT_INVOCATION_ONLY])
                 }
                 EntryPointPayment::SelfOnward => Cow::Borrowed(&[ENTRY_POINT_PAYMENT_SELF_ONWARD]),
-            }
+            };
+            (u8::UID.as_u64(), bytes)
         }
         Ok(Some(stored_value)) => {
             // TODO: Backwards compatibility with old EE, although it's not clear if we should do it
@@ -447,6 +454,7 @@ pub fn casper_read<S: GlobalStateReader, E: Executor>(
     let read_info = ReadInfo {
         data: out_ptr,
         data_size: global_state_raw_bytes.len().try_into_wrapped()?,
+        data_type: type_uid,
     };
 
     let read_info_bytes = safe_transmute::transmute_one_to_bytes(&read_info);
@@ -454,6 +462,7 @@ pub fn casper_read<S: GlobalStateReader, E: Executor>(
     if out_ptr != 0 {
         caller.memory_write(out_ptr, &global_state_raw_bytes)?;
     }
+
     Ok(HOST_ERROR_SUCCESS)
 }
 

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -550,6 +550,7 @@ pub fn casper_return<S: GlobalStateReader, E: Executor>(
     flags: u32,
     data_ptr: u32,
     data_len: u32,
+    data_type_uid: u64,
 ) -> VMResult<()> {
     let ret_cost = caller.context().config.host_function_costs().ret;
     charge_host_function_call(
@@ -562,10 +563,16 @@ pub fn casper_return<S: GlobalStateReader, E: Executor>(
     let data = if data_ptr == 0 {
         None
     } else {
-        let data = caller
+        caller
             .memory_read(data_ptr, data_len.try_into_wrapped()?)
-            .map(Bytes::from)?;
-        Some(data)
+            .map(|data| {
+                let mut buffer = Vec::with_capacity(
+                    data_type_uid.serialized_length() + data.serialized_length()
+                );
+                data_type_uid.write_bytes(&mut buffer).ok()?;
+                data.write_bytes(&mut buffer).ok()?;
+                Some(Bytes::from(data))
+            })?
     };
     Err(VMError::Return { flags, data })
 }

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, num::NonZeroU32, sync::Arc};
 
 use bytes::Bytes;
+use casper_contract_sdk::type_uid::TypeUid;
 use casper_executor_wasm_common::{
     chain_utils,
     entry_point::{
@@ -34,13 +35,12 @@ use casper_types::{
     ByteCodeKind, CLType, CLValue, ContractRuntimeTag, Digest, EntityAddr, EntityEntryPoint,
     EntityKind, EntryPointAccess, EntryPointAddr, EntryPointPayment, EntryPointType,
     EntryPointValue, HashAddr, HostFunctionV2, Key, Package, PackageHash, ProtocolVersion,
-    StoredValue, URef, U512, TaggedBytes,
+    StoredValue, TaggedBytes, URef, U512,
 };
 use either::Either;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use tracing::{error, info, warn};
-use casper_contract_sdk::type_uid::TypeUid;
 
 use crate::{
     abi::{CreateResult, ReadInfo},
@@ -412,7 +412,7 @@ pub fn casper_read<S: GlobalStateReader, E: Executor>(
         Ok(Some(StoredValue::TaggedBytes(raw_bytes))) => {
             let (type_uid, bytes) = raw_bytes.deconstruct();
             (type_uid, Cow::Owned(bytes.take_inner()))
-        },
+        }
         Ok(Some(StoredValue::EntryPoint(EntryPointValue::V1CasperVm(entry_point)))) => {
             let bytes: Cow<[u8]> = match entry_point.entry_point_payment() {
                 EntryPointPayment::Caller => Cow::Borrowed(&[ENTRY_POINT_PAYMENT_CALLER]),
@@ -567,7 +567,7 @@ pub fn casper_return<S: GlobalStateReader, E: Executor>(
             .memory_read(data_ptr, data_len.try_into_wrapped()?)
             .map(|data| {
                 let mut buffer = Vec::with_capacity(
-                    data_type_uid.serialized_length() + data.serialized_length()
+                    data_type_uid.serialized_length() + data.serialized_length(),
                 );
                 data_type_uid.write_bytes(&mut buffer).ok()?;
                 data.write_bytes(&mut buffer).ok()?;

--- a/smart_contracts/sdk/src/casper.rs
+++ b/smart_contracts/sdk/src/casper.rs
@@ -2,17 +2,12 @@
 pub mod native;
 
 use crate::{
-    abi::{CasperABI, EnumVariant},
-    prelude::{
+    abi::{CasperABI, EnumVariant}, prelude::{
         ffi::c_void,
         marker::PhantomData,
         mem::MaybeUninit,
         ptr::{self, NonNull},
-    },
-    reserve_vec_space,
-    serializers::borsh::{BorshDeserialize, BorshSerialize},
-    types::{Address, CallError},
-    Message, ToCallData,
+    }, reserve_vec_space, serializers::borsh::{BorshDeserialize, BorshSerialize}, type_uid::TypeUid, types::{Address, CallError}, Message, ToCallData
 };
 
 use casper_contract_sdk_sys::casper_env_info;
@@ -118,6 +113,7 @@ pub fn read<F: FnOnce(usize) -> Option<ptr::NonNull<u8>>>(
     let mut info = casper_contract_sdk_sys::ReadInfo {
         data: ptr::null(),
         size: 0,
+        type_uid: 0,
     };
 
     extern "C" fn alloc_cb<F: FnOnce(usize) -> Option<ptr::NonNull<u8>>>(
@@ -152,8 +148,35 @@ pub fn read<F: FnOnce(usize) -> Option<ptr::NonNull<u8>>>(
     }
 }
 
-/// Write to the global state.
+/// Write to the global state, typed as an ordinary byte array.
 pub fn write(key: Keyspace, value: &[u8]) -> Result<(), CommonResult> {
+    let (key_space, key_bytes) = match key {
+        Keyspace::State => (KeyspaceTag::State as u64, &[][..]),
+        Keyspace::Context(key_bytes) => (KeyspaceTag::Context as u64, key_bytes),
+        Keyspace::NamedKey(key_bytes) => (KeyspaceTag::NamedKey as u64, key_bytes.as_bytes()),
+        Keyspace::PaymentInfo(payload) => (KeyspaceTag::PaymentInfo as u64, payload.as_bytes()),
+    };
+    let value_type_uid = <[u8]>::UID;
+    let ret = unsafe {
+        casper_contract_sdk_sys::casper_write(
+            key_space,
+            key_bytes.as_ptr(),
+            key_bytes.len(),
+            value.as_ptr(),
+            value.len(),
+            value_type_uid.as_u64(),
+        )
+    };
+    result_from_code(ret)
+}
+
+/// Write typed to global state.
+pub fn write_t<T: BorshSerialize + TypeUid>(
+    key: Keyspace,
+    value: T,
+) -> Result<(), CommonResult> {
+    let value = borsh::to_vec(&value).map_err(|_| CommonResult::InvalidData)?;
+    let value_type_uid = T::UID;
     let (key_space, key_bytes) = match key {
         Keyspace::State => (KeyspaceTag::State as u64, &[][..]),
         Keyspace::Context(key_bytes) => (KeyspaceTag::Context as u64, key_bytes),
@@ -167,6 +190,7 @@ pub fn write(key: Keyspace, value: &[u8]) -> Result<(), CommonResult> {
             key_bytes.len(),
             value.as_ptr(),
             value.len(),
+            value_type_uid.as_u64(),
         )
     };
     result_from_code(ret)
@@ -308,7 +332,7 @@ pub fn upgrade(
     }
 }
 
-/// Read from the global state into a vector.
+/// Read from the global state into a vector of bytes, disregarding the type uid.
 pub fn read_into_vec(key: Keyspace) -> Result<Option<Vec<u8>>, CommonResult> {
     let mut vec = Vec::new();
     let out = read(key, |size| reserve_vec_space(&mut vec, size))?.map(|()| vec);

--- a/smart_contracts/sdk/src/casper.rs
+++ b/smart_contracts/sdk/src/casper.rs
@@ -87,13 +87,14 @@ pub fn copy_input_to(dest: &mut [u8]) -> Option<&[u8]> {
     Some(&dest[..length])
 }
 
-/// Return from the contract.
+/// Return from the contract, tagged as arbitrary u8 array.
 pub fn ret(flags: ReturnFlags, data: Option<&[u8]>) {
     let (data_ptr, data_len) = match data {
         Some(data) => (data.as_ptr(), data.len()),
         None => (ptr::null(), 0),
     };
-    unsafe { casper_contract_sdk_sys::casper_return(flags.bits(), data_ptr, data_len) };
+    let data_type_uid = <[u8]>::UID.as_u64();
+    unsafe { casper_contract_sdk_sys::casper_return(flags.bits(), data_ptr, data_len, data_type_uid) };
     #[cfg(target_arch = "wasm32")]
     unreachable!()
 }

--- a/smart_contracts/sdk/src/casper.rs
+++ b/smart_contracts/sdk/src/casper.rs
@@ -2,12 +2,18 @@
 pub mod native;
 
 use crate::{
-    abi::{CasperABI, EnumVariant}, prelude::{
+    abi::{CasperABI, EnumVariant},
+    prelude::{
         ffi::c_void,
         marker::PhantomData,
         mem::MaybeUninit,
         ptr::{self, NonNull},
-    }, reserve_vec_space, serializers::borsh::{BorshDeserialize, BorshSerialize}, type_uid::TypeUid, types::{Address, CallError}, Message, ToCallData
+    },
+    reserve_vec_space,
+    serializers::borsh::{BorshDeserialize, BorshSerialize},
+    type_uid::TypeUid,
+    types::{Address, CallError},
+    Message, ToCallData,
 };
 
 use casper_contract_sdk_sys::casper_env_info;
@@ -94,7 +100,9 @@ pub fn ret(flags: ReturnFlags, data: Option<&[u8]>) {
         None => (ptr::null(), 0),
     };
     let data_type_uid = <[u8]>::UID.as_u64();
-    unsafe { casper_contract_sdk_sys::casper_return(flags.bits(), data_ptr, data_len, data_type_uid) };
+    unsafe {
+        casper_contract_sdk_sys::casper_return(flags.bits(), data_ptr, data_len, data_type_uid)
+    };
     #[cfg(target_arch = "wasm32")]
     unreachable!()
 }
@@ -172,10 +180,7 @@ pub fn write(key: Keyspace, value: &[u8]) -> Result<(), CommonResult> {
 }
 
 /// Write typed to global state.
-pub fn write_t<T: BorshSerialize + TypeUid>(
-    key: Keyspace,
-    value: T,
-) -> Result<(), CommonResult> {
+pub fn write_t<T: BorshSerialize + TypeUid>(key: Keyspace, value: T) -> Result<(), CommonResult> {
     let value = borsh::to_vec(&value).map_err(|_| CommonResult::InvalidData)?;
     let value_type_uid = T::UID;
     let (key_space, key_bytes) = match key {

--- a/smart_contracts/sdk/src/collections/set.rs
+++ b/smart_contracts/sdk/src/collections/set.rs
@@ -31,7 +31,7 @@ where
 
     pub fn insert(&mut self, key: T) {
         let lookup_key = self.lookup.lookup(self.prefix.as_bytes(), &key);
-        let value: [u8;0] = [];
+        let value: [u8; 0] = [];
         casper::write(Keyspace::Context(lookup_key.as_ref()), &value).unwrap();
     }
 

--- a/smart_contracts/sdk/src/collections/set.rs
+++ b/smart_contracts/sdk/src/collections/set.rs
@@ -31,7 +31,8 @@ where
 
     pub fn insert(&mut self, key: T) {
         let lookup_key = self.lookup.lookup(self.prefix.as_bytes(), &key);
-        casper::write(Keyspace::Context(lookup_key.as_ref()), &[]).unwrap();
+        let value: [u8;0] = [];
+        casper::write(Keyspace::Context(lookup_key.as_ref()), &value).unwrap();
     }
 
     pub fn contains_key(&self, key: T) -> bool {

--- a/smart_contracts/sdk/src/type_uid.rs
+++ b/smart_contracts/sdk/src/type_uid.rs
@@ -1,4 +1,3 @@
-use borsh::{BorshDeserialize, BorshSerialize};
 use xxhash_rust::const_xxh64::xxh64;
 
 const TYPE_UID_SEED: u64 = 0;
@@ -67,10 +66,6 @@ impl Uid {
             b_bytes[6], b_bytes[7],
         ];
         Uid::from_bytes(&preimage)
-    }
-
-    pub const fn serialized_length() -> usize {
-        8
     }
 }
 

--- a/smart_contracts/sdk/src/type_uid.rs
+++ b/smart_contracts/sdk/src/type_uid.rs
@@ -1,3 +1,4 @@
+use borsh::{BorshDeserialize, BorshSerialize};
 use xxhash_rust::const_xxh64::xxh64;
 
 const TYPE_UID_SEED: u64 = 0;
@@ -66,6 +67,10 @@ impl Uid {
             b_bytes[6], b_bytes[7],
         ];
         Uid::from_bytes(&preimage)
+    }
+
+    pub const fn serialized_length() -> usize {
+        8
     }
 }
 
@@ -157,6 +162,10 @@ impl_type_uid_for_tuple!(Tuple9: T1, T2, T3, T4, T5, T6, T7, T8, T9);
 impl_type_uid_for_tuple!(Tuple10: T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
 impl_type_uid_for_tuple!(Tuple11: T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
 impl_type_uid_for_tuple!(Tuple12: T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+
+impl<T: TypeUid> TypeUid for &T {
+    const UID: Uid = T::UID;
+}
 
 #[cfg(test)]
 mod tests {

--- a/smart_contracts/sdk_sys/src/for_each_host_function.rs
+++ b/smart_contracts/sdk_sys/src/for_each_host_function.rs
@@ -17,6 +17,7 @@ macro_rules! for_each_host_function {
                 key_size: usize,
                 value_ptr: *const u8,
                 value_size: usize,
+                value_type_uid: u64,
             ) -> u32;
             pub fn casper_remove(
                 key_space: u64,

--- a/smart_contracts/sdk_sys/src/for_each_host_function.rs
+++ b/smart_contracts/sdk_sys/src/for_each_host_function.rs
@@ -25,7 +25,7 @@ macro_rules! for_each_host_function {
                 key_size: usize,
             ) -> u32;
             pub fn casper_print(msg_ptr: *const u8, msg_size: usize,);
-            pub fn casper_return(flags: u32, data_ptr: *const u8, data_len: usize,);
+            pub fn casper_return(flags: u32, data_ptr: *const u8, data_len: usize, data_type_uid: u64,);
             pub fn casper_copy_input(
                 alloc: extern "C" fn(usize, *mut core::ffi::c_void) -> *mut u8,
                 alloc_ctx: *const core::ffi::c_void,

--- a/smart_contracts/sdk_sys/src/lib.rs
+++ b/smart_contracts/sdk_sys/src/lib.rs
@@ -15,6 +15,8 @@ pub struct ReadInfo {
     pub data: *const u8,
     /// Size in bytes.
     pub size: usize,
+    /// UID of the stored type
+    pub type_uid: u64,
 }
 
 #[repr(C)]

--- a/storage/src/tracking_copy/byte_size.rs
+++ b/storage/src/tracking_copy/byte_size.rs
@@ -47,7 +47,7 @@ impl ByteSize for StoredValue {
                 StoredValue::NamedKey(named_key) => named_key.serialized_length(),
                 StoredValue::Prepayment(prepayment_kind) => prepayment_kind.serialized_length(),
                 StoredValue::EntryPoint(entry_point) => entry_point.serialized_length(),
-                StoredValue::RawBytes(raw_bytes) => raw_bytes.serialized_length(),
+                StoredValue::TaggedBytes(raw_bytes) => raw_bytes.serialized_length(),
             }
     }
 }

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -853,7 +853,7 @@ where
                 StoredValue::Prepayment(_) => {
                     return Ok(query.into_not_found_result("Prepayment value found."))
                 }
-                StoredValue::RawBytes(_) => {
+                StoredValue::TaggedBytes(_) => {
                     return Ok(query.into_not_found_result("RawBytes value found."));
                 }
             }

--- a/types/src/execution/transform_kind.rs
+++ b/types/src/execution/transform_kind.rs
@@ -191,7 +191,7 @@ impl TransformKindV2 {
                     let found = "Message".to_string();
                     Err(StoredValueTypeMismatch::new(expected, found).into())
                 }
-                StoredValue::RawBytes(_) => {
+                StoredValue::TaggedBytes(_) => {
                     let expected = "Contract or Account".to_string();
                     let found = "RawBytes".to_string();
                     Err(StoredValueTypeMismatch::new(expected, found).into())

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -12,17 +12,28 @@ use crate::{
     account::{
         self, action_thresholds::gens::account_action_thresholds_arb,
         associated_keys::gens::account_associated_keys_arb, Account, AccountHash,
-    }, addressable_entity::{
+    },
+    addressable_entity::{
         action_thresholds::gens::action_thresholds_arb, associated_keys::gens::associated_keys_arb,
         ContractRuntimeTag, MessageTopics, NamedKeyAddr, NamedKeyValue, Parameters, Weight,
-    }, block::BlockGlobalAddr, byte_code::ByteCodeKind, bytesrepr::Bytes, contract_messages::{MessageAddr, MessageChecksum, MessageTopicSummary, TopicNameHash}, contracts::{
+    },
+    block::BlockGlobalAddr,
+    byte_code::ByteCodeKind,
+    bytesrepr::Bytes,
+    contract_messages::{MessageAddr, MessageChecksum, MessageTopicSummary, TopicNameHash},
+    contracts::{
         Contract, ContractHash, ContractPackage, ContractPackageStatus, ContractVersionKey,
         ContractVersions, EntryPoint as ContractEntryPoint, EntryPoints as ContractEntryPoints,
         NamedKeys,
-    }, crypto::{
+    },
+    crypto::{
         self,
         gens::{public_key_arb_no_system, secret_key_arb_no_system},
-    }, deploy_info::gens::deploy_info_arb, global_state::{Pointer, TrieMerkleProof, TrieMerkleProofStep}, package::{EntityVersionKey, EntityVersions, Groups, PackageStatus}, system::{
+    },
+    deploy_info::gens::deploy_info_arb,
+    global_state::{Pointer, TrieMerkleProof, TrieMerkleProofStep},
+    package::{EntityVersionKey, EntityVersions, Groups, PackageStatus},
+    system::{
         auction::{
             gens::era_info_arb, Bid, BidAddr, BidKind, DelegationRate, Delegator, DelegatorBid,
             DelegatorKind, Reservation, UnbondingPurse, ValidatorBid, ValidatorCredit,
@@ -30,13 +41,23 @@ use crate::{
         },
         mint::BalanceHoldAddr,
         SystemEntityType,
-    }, tagged_bytes::gens::tagged_bytes_arb, transaction::{
+    },
+    tagged_bytes::gens::tagged_bytes_arb,
+    transaction::{
         gens::deploy_hash_arb, FieldsContainer, InitiatorAddrAndSecretKey, TransactionArgs,
         TransactionRuntimeParams, TransactionV1Payload,
-    }, transfer::{
+    },
+    transfer::{
         gens::{transfer_v1_addr_arb, transfer_v1_arb},
         TransferAddr,
-    }, AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, ByteCode, ByteCodeAddr, CLType, CLValue, Digest, EntityAddr, EntityEntryPoint, EntityKind, EntryPointAccess, EntryPointAddr, EntryPointPayment, EntryPointType, EntryPoints, EraId, Group, InitiatorAddr, Key, NamedArg, Package, Parameter, Phase, PricingMode, ProtocolVersion, PublicKey, RuntimeArgs, SemVer, StoredValue, TimeDiff, Timestamp, Transaction, TransactionEntryPoint, TransactionInvocationTarget, TransactionScheduling, TransactionTarget, TransactionV1, URef, U128, U256, U512
+    },
+    AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, ByteCode, ByteCodeAddr,
+    CLType, CLValue, Digest, EntityAddr, EntityEntryPoint, EntityKind, EntryPointAccess,
+    EntryPointAddr, EntryPointPayment, EntryPointType, EntryPoints, EraId, Group, InitiatorAddr,
+    Key, NamedArg, Package, Parameter, Phase, PricingMode, ProtocolVersion, PublicKey, RuntimeArgs,
+    SemVer, StoredValue, TimeDiff, Timestamp, Transaction, TransactionEntryPoint,
+    TransactionInvocationTarget, TransactionScheduling, TransactionTarget, TransactionV1, URef,
+    U128, U256, U512,
 };
 use proptest::{
     array, bits, bool,

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -12,28 +12,17 @@ use crate::{
     account::{
         self, action_thresholds::gens::account_action_thresholds_arb,
         associated_keys::gens::account_associated_keys_arb, Account, AccountHash,
-    },
-    addressable_entity::{
+    }, addressable_entity::{
         action_thresholds::gens::action_thresholds_arb, associated_keys::gens::associated_keys_arb,
         ContractRuntimeTag, MessageTopics, NamedKeyAddr, NamedKeyValue, Parameters, Weight,
-    },
-    block::BlockGlobalAddr,
-    byte_code::ByteCodeKind,
-    bytesrepr::Bytes,
-    contract_messages::{MessageAddr, MessageChecksum, MessageTopicSummary, TopicNameHash},
-    contracts::{
+    }, block::BlockGlobalAddr, byte_code::ByteCodeKind, bytesrepr::Bytes, contract_messages::{MessageAddr, MessageChecksum, MessageTopicSummary, TopicNameHash}, contracts::{
         Contract, ContractHash, ContractPackage, ContractPackageStatus, ContractVersionKey,
         ContractVersions, EntryPoint as ContractEntryPoint, EntryPoints as ContractEntryPoints,
         NamedKeys,
-    },
-    crypto::{
+    }, crypto::{
         self,
         gens::{public_key_arb_no_system, secret_key_arb_no_system},
-    },
-    deploy_info::gens::deploy_info_arb,
-    global_state::{Pointer, TrieMerkleProof, TrieMerkleProofStep},
-    package::{EntityVersionKey, EntityVersions, Groups, PackageStatus},
-    system::{
+    }, deploy_info::gens::deploy_info_arb, global_state::{Pointer, TrieMerkleProof, TrieMerkleProofStep}, package::{EntityVersionKey, EntityVersions, Groups, PackageStatus}, system::{
         auction::{
             gens::era_info_arb, Bid, BidAddr, BidKind, DelegationRate, Delegator, DelegatorBid,
             DelegatorKind, Reservation, UnbondingPurse, ValidatorBid, ValidatorCredit,
@@ -41,22 +30,13 @@ use crate::{
         },
         mint::BalanceHoldAddr,
         SystemEntityType,
-    },
-    transaction::{
+    }, tagged_bytes::gens::tagged_bytes_arb, transaction::{
         gens::deploy_hash_arb, FieldsContainer, InitiatorAddrAndSecretKey, TransactionArgs,
         TransactionRuntimeParams, TransactionV1Payload,
-    },
-    transfer::{
+    }, transfer::{
         gens::{transfer_v1_addr_arb, transfer_v1_arb},
         TransferAddr,
-    },
-    AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, ByteCode, ByteCodeAddr,
-    CLType, CLValue, Digest, EntityAddr, EntityEntryPoint, EntityKind, EntryPointAccess,
-    EntryPointAddr, EntryPointPayment, EntryPointType, EntryPoints, EraId, Group, InitiatorAddr,
-    Key, NamedArg, Package, Parameter, Phase, PricingMode, ProtocolVersion, PublicKey, RuntimeArgs,
-    SemVer, StoredValue, TimeDiff, Timestamp, Transaction, TransactionEntryPoint,
-    TransactionInvocationTarget, TransactionScheduling, TransactionTarget, TransactionV1, URef,
-    U128, U256, U512,
+    }, AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, ByteCode, ByteCodeAddr, CLType, CLValue, Digest, EntityAddr, EntityEntryPoint, EntityKind, EntryPointAccess, EntryPointAddr, EntryPointPayment, EntryPointType, EntryPoints, EraId, Group, InitiatorAddr, Key, NamedArg, Package, Parameter, Phase, PricingMode, ProtocolVersion, PublicKey, RuntimeArgs, SemVer, StoredValue, TimeDiff, Timestamp, Transaction, TransactionEntryPoint, TransactionInvocationTarget, TransactionScheduling, TransactionTarget, TransactionV1, URef, U128, U256, U512
 };
 use proptest::{
     array, bits, bool,
@@ -984,7 +964,7 @@ pub fn stored_value_arb() -> impl Strategy<Value = StoredValue> {
         message_topic_summary_arb().prop_map(StoredValue::MessageTopic),
         message_summary_arb().prop_map(StoredValue::Message),
         named_key_value_arb().prop_map(StoredValue::NamedKey),
-        collection::vec(any::<u8>(), 0..1000).prop_map(StoredValue::RawBytes),
+        tagged_bytes_arb().prop_map(StoredValue::TaggedBytes),
     ]
     .prop_map(|stored_value|
             // The following match statement is here only to make sure
@@ -1010,7 +990,7 @@ pub fn stored_value_arb() -> impl Strategy<Value = StoredValue> {
                 StoredValue::NamedKey(_) => stored_value,
                 StoredValue::Prepayment(_) => stored_value,
                 StoredValue::EntryPoint(_) => stored_value,
-                StoredValue::RawBytes(_) => stored_value,
+                StoredValue::TaggedBytes(_) => stored_value,
         })
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -65,6 +65,7 @@ pub(crate) mod serde_helpers;
 mod stored_value;
 pub mod system;
 mod tagged;
+mod tagged_bytes;
 #[cfg(any(feature = "testing", test))]
 pub mod testing;
 mod timestamp;
@@ -74,7 +75,6 @@ mod transfer_result;
 mod uint;
 mod uref;
 mod validator_change;
-mod tagged_bytes;
 
 #[cfg(all(feature = "std", any(feature = "std-fs-io", test)))]
 use libc::{c_long, sysconf, _SC_PAGESIZE};
@@ -113,15 +113,6 @@ pub use block::{
 pub use block::{TestBlockBuilder, TestBlockV1Builder};
 pub use block_time::{BlockTime, HoldsEpoch, BLOCKTIME_SERIALIZED_LENGTH};
 pub use byte_code::{ByteCode, ByteCodeAddr, ByteCodeHash, ByteCodeKind};
-pub use cl_type::{named_key_type, CLType, CLTyped};
-#[cfg(feature = "json-schema")]
-pub use cl_value::cl_value_to_json;
-pub use cl_value::{
-    handle_stored_dictionary_value, CLTypeMismatch, CLValue, CLValueError, ChecksumRegistry,
-    DictionaryValue as CLValueDictionary, SystemHashRegistry,
-};
-pub use global_state::Pointer;
-pub use tagged_bytes::{TaggedBytes};
 #[cfg(any(feature = "std", test))]
 pub use chainspec::{
     AccountConfig, AccountsConfig, ActivationPoint, AdministratorAccount, AuctionCosts,
@@ -154,6 +145,13 @@ pub use chainspec::{
     DEFAULT_MIN_TRANSFER_MOTES, DEFAULT_MUL_COST, DEFAULT_NEW_DICTIONARY_COST, DEFAULT_NOP_COST,
     DEFAULT_STORE_COST, DEFAULT_TRANSFER_COST, DEFAULT_UNREACHABLE_COST, DEFAULT_WASM_MAX_MEMORY,
 };
+pub use cl_type::{named_key_type, CLType, CLTyped};
+#[cfg(feature = "json-schema")]
+pub use cl_value::cl_value_to_json;
+pub use cl_value::{
+    handle_stored_dictionary_value, CLTypeMismatch, CLValue, CLValueError, ChecksumRegistry,
+    DictionaryValue as CLValueDictionary, SystemHashRegistry,
+};
 pub use contract_wasm::{ContractWasm, ContractWasmHash};
 #[doc(inline)]
 pub use contracts::{Contract, NamedKeys};
@@ -166,6 +164,7 @@ pub use digest::{
 pub use display_iter::DisplayIter;
 pub use era_id::EraId;
 pub use gas::Gas;
+pub use global_state::Pointer;
 #[cfg(feature = "json-schema")]
 pub use json_pretty_printer::json_pretty_print;
 #[doc(inline)]
@@ -189,6 +188,7 @@ pub use stored_value::{
 };
 pub use system::mint::METHOD_TRANSFER;
 pub use tagged::Tagged;
+pub use tagged_bytes::TaggedBytes;
 #[cfg(any(feature = "std", test))]
 pub use timestamp::serde_option_time_diff;
 pub use timestamp::{TimeDiff, Timestamp};

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -74,6 +74,7 @@ mod transfer_result;
 mod uint;
 mod uref;
 mod validator_change;
+mod tagged_bytes;
 
 #[cfg(all(feature = "std", any(feature = "std-fs-io", test)))]
 use libc::{c_long, sysconf, _SC_PAGESIZE};
@@ -120,7 +121,7 @@ pub use cl_value::{
     DictionaryValue as CLValueDictionary, SystemHashRegistry,
 };
 pub use global_state::Pointer;
-
+pub use tagged_bytes::{TaggedBytes};
 #[cfg(any(feature = "std", test))]
 pub use chainspec::{
     AccountConfig, AccountsConfig, ActivationPoint, AdministratorAccount, AuctionCosts,

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -16,10 +16,19 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 
 use crate::{
-    account::Account, addressable_entity::NamedKeyValue, bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH}, contract_messages::{MessageChecksum, MessageTopicSummary}, contract_wasm::ContractWasm, contracts::{Contract, ContractPackage}, package::Package, system::{
+    account::Account,
+    addressable_entity::NamedKeyValue,
+    bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    contract_messages::{MessageChecksum, MessageTopicSummary},
+    contract_wasm::ContractWasm,
+    contracts::{Contract, ContractPackage},
+    package::Package,
+    system::{
         auction::{Bid, BidKind, EraInfo, Unbond, UnbondingPurse, WithdrawPurse},
         prepayment::PrepaymentKind,
-    }, tagged_bytes::TaggedBytes, AddressableEntity, ByteCode, CLValue, DeployInfo, EntryPointValue, TransferV1
+    },
+    tagged_bytes::TaggedBytes,
+    AddressableEntity, ByteCode, CLValue, DeployInfo, EntryPointValue, TransferV1,
 };
 pub use global_state_identifier::GlobalStateIdentifier;
 pub use type_mismatch::TypeMismatch;
@@ -122,8 +131,8 @@ pub enum StoredValue {
     Prepayment(PrepaymentKind),
     /// An entrypoint record.
     EntryPoint(EntryPointValue),
-    /// Bytes tagged with a unique type id. Similar to a [`crate::StoredValue::CLValue`] but does not incur overhead of a
-    /// [`crate::CLValue`] and [`crate::CLType`].
+    /// Bytes tagged with a unique type id. Similar to a [`crate::StoredValue::CLValue`] but does
+    /// not incur overhead of a [`crate::CLValue`] and [`crate::CLType`].
     TaggedBytes(TaggedBytes),
 }
 
@@ -869,11 +878,10 @@ impl FromBytes for StoredValue {
                     (StoredValue::EntryPoint(entry_point), remainder)
                 })
             }
-            tag if tag == StoredValueTag::TaggedBytes as u8 => {
-                TaggedBytes::from_bytes(remainder).map(|(tagged_bytes, remainder)| {
+            tag if tag == StoredValueTag::TaggedBytes as u8 => TaggedBytes::from_bytes(remainder)
+                .map(|(tagged_bytes, remainder)| {
                     (StoredValue::TaggedBytes(tagged_bytes), remainder)
-                })
-            }
+                }),
             _ => Err(Error::Formatting),
         }
     }
@@ -1272,10 +1280,7 @@ mod tests {
 
     #[test]
     fn json_serialization_of_tagged_bytes() {
-        let stored_value = StoredValue::TaggedBytes(TaggedBytes::new(
-            0,
-            vec![1, 2, 3, 4].into(),
-        ));
+        let stored_value = StoredValue::TaggedBytes(TaggedBytes::new(0, vec![1, 2, 3, 4].into()));
         assert_eq!(
             serde_json::to_string(&stored_value).unwrap(),
             r#"{"TaggedBytes":{"type_uid":0,"bytes":"01020304"}}"#

--- a/types/src/stored_value.rs
+++ b/types/src/stored_value.rs
@@ -16,18 +16,10 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 
 use crate::{
-    account::Account,
-    addressable_entity::NamedKeyValue,
-    bytesrepr::{self, Bytes, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    contract_messages::{MessageChecksum, MessageTopicSummary},
-    contract_wasm::ContractWasm,
-    contracts::{Contract, ContractPackage},
-    package::Package,
-    system::{
+    account::Account, addressable_entity::NamedKeyValue, bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH}, contract_messages::{MessageChecksum, MessageTopicSummary}, contract_wasm::ContractWasm, contracts::{Contract, ContractPackage}, package::Package, system::{
         auction::{Bid, BidKind, EraInfo, Unbond, UnbondingPurse, WithdrawPurse},
         prepayment::PrepaymentKind,
-    },
-    AddressableEntity, ByteCode, CLValue, DeployInfo, EntryPointValue, TransferV1,
+    }, tagged_bytes::TaggedBytes, AddressableEntity, ByteCode, CLValue, DeployInfo, EntryPointValue, TransferV1
 };
 pub use global_state_identifier::GlobalStateIdentifier;
 pub use type_mismatch::TypeMismatch;
@@ -76,8 +68,8 @@ pub enum StoredValueTag {
     Prepayment = 18,
     /// An entrypoint record.
     EntryPoint = 19,
-    /// Raw bytes.
-    RawBytes = 20,
+    /// Tagged bytes.
+    TaggedBytes = 20,
 }
 
 /// A value stored in Global State.
@@ -130,9 +122,9 @@ pub enum StoredValue {
     Prepayment(PrepaymentKind),
     /// An entrypoint record.
     EntryPoint(EntryPointValue),
-    /// Raw bytes. Similar to a [`crate::StoredValue::CLValue`] but does not incur overhead of a
+    /// Bytes tagged with a unique type id. Similar to a [`crate::StoredValue::CLValue`] but does not incur overhead of a
     /// [`crate::CLValue`] and [`crate::CLType`].
-    RawBytes(#[cfg_attr(feature = "json-schema", schemars(with = "String"))] Vec<u8>),
+    TaggedBytes(TaggedBytes),
 }
 
 impl StoredValue {
@@ -284,10 +276,10 @@ impl StoredValue {
         }
     }
 
-    /// Returns raw bytes if this is a `RawBytes` variant.
-    pub fn as_raw_bytes(&self) -> Option<&[u8]> {
+    /// Returns [`TaggedBytes`] if this is a `TaggedBytes` variant.
+    pub fn as_tagged_bytes(&self) -> Option<&TaggedBytes> {
         match self {
-            StoredValue::RawBytes(bytes) => Some(bytes),
+            StoredValue::TaggedBytes(tagged) => Some(tagged),
             _ => None,
         }
     }
@@ -445,7 +437,7 @@ impl StoredValue {
             StoredValue::NamedKey(_) => "NamedKey".to_string(),
             StoredValue::Prepayment(_) => "Prepayment".to_string(),
             StoredValue::EntryPoint(_) => "EntryPoint".to_string(),
-            StoredValue::RawBytes(_) => "RawBytes".to_string(),
+            StoredValue::TaggedBytes(_) => "RawBytes".to_string(),
         }
     }
 
@@ -472,7 +464,7 @@ impl StoredValue {
             StoredValue::NamedKey(_) => StoredValueTag::NamedKey,
             StoredValue::Prepayment(_) => StoredValueTag::Prepayment,
             StoredValue::EntryPoint(_) => StoredValueTag::EntryPoint,
-            StoredValue::RawBytes(_) => StoredValueTag::RawBytes,
+            StoredValue::TaggedBytes(_) => StoredValueTag::TaggedBytes,
         }
     }
 
@@ -780,7 +772,7 @@ impl ToBytes for StoredValue {
                 StoredValue::NamedKey(named_key_value) => named_key_value.serialized_length(),
                 StoredValue::Prepayment(prepayment_kind) => prepayment_kind.serialized_length(),
                 StoredValue::EntryPoint(entry_point_value) => entry_point_value.serialized_length(),
-                StoredValue::RawBytes(bytes) => bytes.serialized_length(),
+                StoredValue::TaggedBytes(bytes) => bytes.serialized_length(),
             }
     }
 
@@ -809,7 +801,7 @@ impl ToBytes for StoredValue {
             StoredValue::NamedKey(named_key_value) => named_key_value.write_bytes(writer),
             StoredValue::Prepayment(prepayment_kind) => prepayment_kind.write_bytes(writer),
             StoredValue::EntryPoint(entry_point_value) => entry_point_value.write_bytes(writer),
-            StoredValue::RawBytes(bytes) => bytes.write_bytes(writer),
+            StoredValue::TaggedBytes(bytes) => bytes.write_bytes(writer),
         }
     }
 }
@@ -877,9 +869,10 @@ impl FromBytes for StoredValue {
                     (StoredValue::EntryPoint(entry_point), remainder)
                 })
             }
-            tag if tag == StoredValueTag::RawBytes as u8 => {
-                let (bytes, remainder) = Bytes::from_bytes(remainder)?;
-                Ok((StoredValue::RawBytes(bytes.into()), remainder))
+            tag if tag == StoredValueTag::TaggedBytes as u8 => {
+                TaggedBytes::from_bytes(remainder).map(|(tagged_bytes, remainder)| {
+                    (StoredValue::TaggedBytes(tagged_bytes), remainder)
+                })
             }
             _ => Err(Error::Formatting),
         }
@@ -923,7 +916,7 @@ pub mod serde_helpers {
         NamedKey(&'a NamedKeyValue),
         Prepayment(&'a PrepaymentKind),
         EntryPoint(&'a EntryPointValue),
-        RawBytes(Bytes),
+        TaggedBytes(&'a TaggedBytes),
     }
 
     /// A value stored in Global State.
@@ -979,7 +972,7 @@ pub mod serde_helpers {
         Prepayment(PrepaymentKind),
         /// Raw bytes. Similar to a [`crate::StoredValue::CLValue`] but does not incur overhead of
         /// a [`crate::CLValue`] and [`crate::CLType`].
-        RawBytes(Bytes),
+        TaggedBytes(TaggedBytes),
     }
 
     impl<'a> From<&'a StoredValue> for HumanReadableSerHelper<'a> {
@@ -1015,9 +1008,7 @@ pub mod serde_helpers {
                 StoredValue::NamedKey(payload) => HumanReadableSerHelper::NamedKey(payload),
                 StoredValue::Prepayment(payload) => HumanReadableSerHelper::Prepayment(payload),
                 StoredValue::EntryPoint(payload) => HumanReadableSerHelper::EntryPoint(payload),
-                StoredValue::RawBytes(bytes) => {
-                    HumanReadableSerHelper::RawBytes(bytes.as_slice().into())
-                }
+                StoredValue::TaggedBytes(payload) => HumanReadableSerHelper::TaggedBytes(payload),
             }
         }
     }
@@ -1081,7 +1072,7 @@ pub mod serde_helpers {
                 }
                 HumanReadableDeserHelper::NamedKey(payload) => StoredValue::NamedKey(payload),
                 HumanReadableDeserHelper::EntryPoint(payload) => StoredValue::EntryPoint(payload),
-                HumanReadableDeserHelper::RawBytes(bytes) => StoredValue::RawBytes(bytes.into()),
+                HumanReadableDeserHelper::TaggedBytes(payload) => StoredValue::TaggedBytes(payload),
                 HumanReadableDeserHelper::Prepayment(prepayment_kind) => {
                     StoredValue::Prepayment(prepayment_kind)
                 }
@@ -1118,7 +1109,7 @@ impl<'de> Deserialize<'de> for StoredValue {
 
 #[cfg(test)]
 mod tests {
-    use crate::{bytesrepr, gens, StoredValue};
+    use crate::{bytesrepr, gens, tagged_bytes::TaggedBytes, StoredValue};
     use proptest::proptest;
     use serde_json::Value;
 
@@ -1280,11 +1271,14 @@ mod tests {
     }
 
     #[test]
-    fn json_serialization_of_raw_bytes() {
-        let stored_value = StoredValue::RawBytes(vec![1, 2, 3, 4]);
+    fn json_serialization_of_tagged_bytes() {
+        let stored_value = StoredValue::TaggedBytes(TaggedBytes::new(
+            0,
+            vec![1, 2, 3, 4].into(),
+        ));
         assert_eq!(
             serde_json::to_string(&stored_value).unwrap(),
-            r#"{"RawBytes":"01020304"}"#
+            r#"{"TaggedBytes":{"type_uid":0,"bytes":"01020304"}}"#
         );
     }
 

--- a/types/src/tagged_bytes.rs
+++ b/types/src/tagged_bytes.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
 #[cfg(feature = "json-schema")]
@@ -18,10 +20,7 @@ pub struct TaggedBytes {
 impl TaggedBytes {
     // Ctor.
     pub fn new(type_uid: u64, bytes: Bytes) -> Self {
-        Self {
-            type_uid,
-            bytes,
-        }
+        Self { type_uid, bytes }
     }
 
     pub fn deconstruct(self) -> (u64, Bytes) {
@@ -37,8 +36,7 @@ impl ToBytes for TaggedBytes {
     }
 
     fn serialized_length(&self) -> usize {
-        self.type_uid.serialized_length() +
-        self.bytes.serialized_length()
+        self.type_uid.serialized_length() + self.bytes.serialized_length()
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
@@ -52,10 +50,7 @@ impl FromBytes for TaggedBytes {
         let (type_uid, remainder) = u64::from_bytes(bytes)?;
         let (bytes, remainder) = Bytes::from_bytes(remainder)?;
 
-        Ok((Self {
-            type_uid,
-            bytes
-        }, remainder))
+        Ok((Self { type_uid, bytes }, remainder))
     }
 }
 
@@ -63,15 +58,17 @@ impl FromBytes for TaggedBytes {
 #[cfg(any(feature = "testing", feature = "gens", test))]
 pub(crate) mod gens {
     use crate::{bytesrepr::Bytes, tagged_bytes::TaggedBytes};
-    use proptest::{collection, prelude::{any, Strategy}};
+    use proptest::{
+        collection,
+        prelude::{any, Strategy},
+    };
 
     pub fn tagged_bytes_arb() -> impl Strategy<Value = TaggedBytes> {
-        (
-            any::<u64>(),
-            collection::vec(any::<u8>(), 0..1000)
-        ).prop_map(|(type_uid, bytes)| TaggedBytes {
-            type_uid,
-            bytes: Bytes::from(bytes),
+        (any::<u64>(), collection::vec(any::<u8>(), 0..1000)).prop_map(|(type_uid, bytes)| {
+            TaggedBytes {
+                type_uid,
+                bytes: Bytes::from(bytes),
+            }
         })
     }
 }

--- a/types/src/tagged_bytes.rs
+++ b/types/src/tagged_bytes.rs
@@ -1,0 +1,77 @@
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::bytesrepr::{self, Bytes, Error, FromBytes, ToBytes};
+
+/// A container for arbitrary bytes, tagged with a unique type id.
+#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub struct TaggedBytes {
+    type_uid: u64,
+    bytes: Bytes,
+}
+
+impl TaggedBytes {
+    // Ctor.
+    pub fn new(type_uid: u64, bytes: Bytes) -> Self {
+        Self {
+            type_uid,
+            bytes,
+        }
+    }
+
+    pub fn deconstruct(self) -> (u64, Bytes) {
+        (self.type_uid, self.bytes)
+    }
+}
+
+impl ToBytes for TaggedBytes {
+    fn to_bytes(&self) -> Result<Vec<u8>, crate::bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.type_uid.serialized_length() +
+        self.bytes.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        self.type_uid.write_bytes(writer)?;
+        self.bytes.write_bytes(writer)
+    }
+}
+
+impl FromBytes for TaggedBytes {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let (type_uid, remainder) = u64::from_bytes(bytes)?;
+        let (bytes, remainder) = Bytes::from_bytes(remainder)?;
+
+        Ok((Self {
+            type_uid,
+            bytes
+        }, remainder))
+    }
+}
+
+/// Generators for [`TaggedBytes`].
+#[cfg(any(feature = "testing", feature = "gens", test))]
+pub(crate) mod gens {
+    use crate::{bytesrepr::Bytes, tagged_bytes::TaggedBytes};
+    use proptest::{collection, prelude::{any, Strategy}};
+
+    pub fn tagged_bytes_arb() -> impl Strategy<Value = TaggedBytes> {
+        (
+            any::<u64>(),
+            collection::vec(any::<u8>(), 0..1000)
+        ).prop_map(|(type_uid, bytes)| TaggedBytes {
+            type_uid,
+            bytes: Bytes::from(bytes),
+        })
+    }
+}


### PR DESCRIPTION
Extends ``ReadInfo`` to include value type uid, makes ``casper_write`` and ``casper_read`` aware of type uids, replaces ``StoredValue::RawBytes`` with ``StoredValue::TaggedBytes`` which prepends the type uid before the bytes. Makes appropriate changes to the smart contract sdk.